### PR TITLE
fix carousel effect not working on page load

### DIFF
--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -22,11 +22,10 @@ const wrappedDistance = (a: number, b: number) => {
 
 const setOpacity = (emblaApi: EmblaCarouselType) => {
   const slideNodes = emblaApi.slideNodes();
-  const slidesInView = slideNodes.map((_, index) => index);
 
   const currentPosition = emblaApi.scrollProgress();
 
-  slidesInView.forEach((slideIndex) => {
+  slideNodes.forEach((_, slideIndex) => {
     const slidePosition = emblaApi.scrollSnapList()[slideIndex];
     const opacity = clamp(
       1 - wrappedDistance(slidePosition, currentPosition) * 8.4,
@@ -47,10 +46,9 @@ const Carousel: React.FC<PropType> = ({ slides, options }) => {
 
   useEffect(() => {
     if (!emblaApi) return;
-    
+
     setOpacity(emblaApi);
     emblaApi.on("reInit", setOpacity).on("scroll", setOpacity);
-
   }, [emblaApi]);
 
   return (

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -22,7 +22,7 @@ const wrappedDistance = (a: number, b: number) => {
 
 const setOpacity = (emblaApi: EmblaCarouselType) => {
   const slideNodes = emblaApi.slideNodes();
-  const slidesInView = emblaApi.slidesInView();
+  const slidesInView = slideNodes.map((_, index) => index);
 
   const currentPosition = emblaApi.scrollProgress();
 
@@ -47,8 +47,10 @@ const Carousel: React.FC<PropType> = ({ slides, options }) => {
 
   useEffect(() => {
     if (!emblaApi) return;
-
+    
+    setOpacity(emblaApi);
     emblaApi.on("reInit", setOpacity).on("scroll", setOpacity);
+
   }, [emblaApi]);
 
   return (


### PR DESCRIPTION
The carousel's opacity effect was not in use at page load and would only kick in after resizing the window or scrolling the carousel.

This was fixed by
- Adding a setOpacity call in the useEffect. (adding it to the init-event did nothing, see [here](https://github.com/davidjerleke/embla-carousel/discussions/379#discussioncomment-3759962))
- Setting the opacity for all slides instead of `emblaApi.slidesInView()`. The slides in view starts off empty and only populates on scroll, dont know why. I'd wager we wont have enough slides for this to matter performance wise